### PR TITLE
Combined dependency updates (2023-09-23)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.6.0</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.5.0 to 3.6.0](https://github.com/javiertuya/branch-snapshots/pull/18)