### PR TITLE
Combined dependency updates (2024-03-06)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # NOTE: deploy args use the profile `publish-github` that specifies the github repository server (see pom.xml)
-      - uses: javiertuya/branch-snapshots-action@v1.1.0
+      - uses: javiertuya/branch-snapshots-action@v1.2.2
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           java-version: '8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     #    working-directory: java
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select Java Version
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/checkout from 3 to 4](https://github.com/javiertuya/branch-snapshots/pull/31)
- [Bump actions/setup-java from 3 to 4](https://github.com/javiertuya/branch-snapshots/pull/30)
- [Bump javiertuya/branch-snapshots-action from 1.1.0 to 1.2.2](https://github.com/javiertuya/branch-snapshots/pull/29)