### PR TITLE
Combined dependency updates (2024-05-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # NOTE: deploy args use the profile `publish-github` that specifies the github repository server (see pom.xml)
-      - uses: javiertuya/branch-snapshots-action@v1.2.2
+      - uses: javiertuya/branch-snapshots-action@v1.2.3
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           java-version: '8'

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-gpg-plugin</artifactId>
-							<version>3.2.2</version>
+							<version>3.2.4</version>
 							<executions>
 								<execution>
 									<id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.12</version>
+			<version>2.0.13</version>
 		</dependency>
 	</dependencies>
 	


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump javiertuya/branch-snapshots-action from 1.2.2 to 1.2.3](https://github.com/javiertuya/branch-snapshots/pull/37)
- [Bump org.apache.maven.plugins:maven-source-plugin from 3.3.0 to 3.3.1](https://github.com/javiertuya/branch-snapshots/pull/36)
- [Bump org.slf4j:slf4j-api from 2.0.12 to 2.0.13](https://github.com/javiertuya/branch-snapshots/pull/35)
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.2 to 3.2.4](https://github.com/javiertuya/branch-snapshots/pull/34)