### PR TITLE
Combined dependency updates (2024-06-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 						<plugin>
 							<groupId>org.sonatype.plugins</groupId>
 							<artifactId>nexus-staging-maven-plugin</artifactId>
-							<version>1.6.13</version>
+							<version>1.7.0</version>
 							<extensions>true</extensions>
 							<configuration>
 								<serverId>ossrh</serverId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.sonatype.plugins:nexus-staging-maven-plugin from 1.6.13 to 1.7.0](https://github.com/javiertuya/branch-snapshots/pull/40)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.6.3 to 3.7.0](https://github.com/javiertuya/branch-snapshots/pull/39)