### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-gpg-plugin</artifactId>
-							<version>3.2.4</version>
+							<version>3.2.5</version>
 							<executions>
 								<execution>
 									<id>sign-artifacts</id>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.4 to 3.2.5](https://github.com/javiertuya/branch-snapshots/pull/45)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0](https://github.com/javiertuya/branch-snapshots/pull/44)
- [Bump org.slf4j:slf4j-api from 2.0.13 to 2.0.16](https://github.com/javiertuya/branch-snapshots/pull/43)