### PR TITLE
Combined dependency updates (2024-12-03)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.11.1</version>
 				<configuration>
 					<quiet>true</quiet>
 					<doclint>none</doclint>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.10.1 to 3.11.1](https://github.com/javiertuya/branch-snapshots/pull/50)