### PR TITLE
Combined dependency updates (2025-08-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-gpg-plugin</artifactId>
-							<version>3.2.7</version>
+							<version>3.2.8</version>
 							<executions>
 								<execution>
 									<id>sign-artifacts</id>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.7 to 3.2.8](https://github.com/javiertuya/branch-snapshots/pull/55)