### PR TITLE
Combined dependency updates (2025-12-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     #    working-directory: java
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.4.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-source-plugin from 3.3.1 to 3.4.0](https://github.com/javiertuya/branch-snapshots/pull/62)
- [Bump actions/checkout from 5 to 6](https://github.com/javiertuya/branch-snapshots/pull/61)