### PR TITLE
Combined dependency updates (2026-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # NOTE: deploy args use the profile `publish-github` that specifies the github repository server (see pom.xml)
-      - uses: javiertuya/branch-snapshots-action@v1.2.3
+      - uses: javiertuya/branch-snapshots-action@v2.0.0
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           java-version: '8'


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump javiertuya/branch-snapshots-action from 1.2.3 to 2.0.0](https://github.com/javiertuya/branch-snapshots/pull/64)