### PR TITLE
ci: fix the publish-java-snapshot guard for dependabot and dashgit branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
         run: mvn test -Dmaven.test.failure.ignore=true -U --no-transfer-progress
 
   publish-java-snapshot:
-    #avoid publishing PRs and dependabot branches
-    if: ${{ github.event_name != 'pull_request' && !contains('/head/refs/dependabot/', github.ref) && !contains('/head/refs/dashgit/combined/', github.ref) }}
+    #avoid publishing PRs and the dependabot and dashgit branches
+    if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/heads/dependabot/') && !startsWith(github.ref, 'refs/heads/dashgit/combined/') }}
     runs-on: ubuntu-latest
     steps:
       # NOTE: deploy args use the profile `publish-github` that specifies the github repository server (see pom.xml)


### PR DESCRIPTION
The contains() conditions never matched: their arguments were swapped and the
branch prefixes misspelled (/head/refs/ instead of refs/heads/), so snapshots
were published from branches that should be excluded.

- replace them with the startsWith() checks used in the other repositories,
  covering both dependabot/** and dashgit/combined/**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
